### PR TITLE
rename cocoapod lib -> RxUIAlertController

### DIFF
--- a/RxUIAlertController.podspec
+++ b/RxUIAlertController.podspec
@@ -7,9 +7,9 @@
 #
 
 Pod::Spec.new do |s|
-  s.name         = "RxAlertExtension"
+  s.name         = "RxUIAlertController"
   s.version      = "1.0.0"
-  s.summary      = "RxAlertExtension"
+  s.summary      = "RxUIAlertController"
   s.description  = <<-DESC
                       Extension UIAlertController with Rx.
                       Use UIAlertController with Rx.


### PR DESCRIPTION
The name of cocoapods library has been changed again.