### PR TITLE
The name of cocoapods library has been changed again.

### DIFF
--- a/RxUIAlert.podspec
+++ b/RxUIAlert.podspec
@@ -7,9 +7,9 @@
 #
 
 Pod::Spec.new do |s|
-  s.name         = "RxUIAlertController"
+  s.name         = "RxUIAlert"
   s.version      = "1.0.0"
-  s.summary      = "RxUIAlertController"
+  s.summary      = "RxUIAlert"
   s.description  = <<-DESC
                       Extension UIAlertController with Rx.
                       Use UIAlertController with Rx.


### PR DESCRIPTION
 # Overview

rename -> RxUIAlert

The name of cocoapods library has been changed again.
