### PR TITLE
fix link url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We have made it easy to implement UIAlertController using RxSwift.
 
 |build|status|
 |:-------|:---|
-|travis CI|![](https://travis-ci.org/RxSwiftCommunity/RxAlert.svg?branch=master)|
+|travis CI|[![](https://travis-ci.org/RxSwiftCommunity/RxAlert.svg?branch=master)](https://travis-ci.org/RxSwiftCommunity/RxAlert)|
 
 ## Carthage
 


### PR DESCRIPTION
# Overview

The link URL has been changed.
Direction:
https://travis-ci.org/RxSwiftCommunity/RxAlert