### PR TITLE
Change `RxAlert` function return type & calling style

### DIFF
--- a/RxAlert/UIViewController+.swift
+++ b/RxAlert/UIViewController+.swift
@@ -28,19 +28,19 @@ import RxCocoa
 import UIKit
 // MARK: - UIAlertController
 extension UIAlertController {
-    public func addAction(actions: [AlertAction]) -> Observable<OutputAction> {
-        return Observable.create { [weak self] observer in
+    public func addAction(actions: [AlertAction]) -> Single<OutputAction> {
+        return Single.create { [weak self] observer in
             guard let self = self else { return Disposables.create() }
             actions.forEach { action in
                 if let textField = action.textField {
                     self.addTextField { text in
                         text.config(textField)
                     }
-                }else{
-                    self.addAction(UIAlertAction(title: action.title, style: action.style, handler: {[unowned self] _ in
-                        observer.on(.next((OutputAction(index: action.type, textFields: self.textFields))))
-                        observer.on(.completed)
-                    }))
+                } else {
+                    let action = UIAlertAction(title: action.title, style: action.style) { [unowned self] _ in
+                        observer(.success(OutputAction(index: action.type, textFields: self.textFields)))
+                    }
+                    self.addAction(action)
                 }
             }
             return Disposables.create { self.dismiss(animated: true) }
@@ -54,7 +54,7 @@ extension UIViewController {
                       message: String? = nil,
                       actions: [AlertAction] = [AlertAction(title: "OK")],
                       preferredStyle: UIAlertController.Style = .alert,
-                      vc: UIViewController? = nil) -> Observable<OutputAction> {
+                      vc: UIViewController? = nil) -> Single<OutputAction> {
         let parentVc = vc ?? self
         let alertController = UIAlertController(title: title, message: message, preferredStyle: preferredStyle)
         return

--- a/RxAlertExample/ViewController.swift
+++ b/RxAlertExample/ViewController.swift
@@ -46,38 +46,38 @@ class ViewController: UIViewController {
                 self.tableView.deselectRow(at: index, animated: true)
                 switch index.row {
                 case 0:
-                    self.alert(title: "RxAlert",
+                    self.rx.alert(title: "RxAlert",
                                message: "RxAlert Message")
                         .observeOn(MainScheduler.instance)
-                        .subscribe(onNext: { index in
+                        .subscribe(onSuccess: { index in
                             print("index: \(index)")
                         })
                         .disposed(by: self.disposeBag)
                     break
                 case 1:
-                    self.alert(title: "RxAlert",
+                    self.rx.alert(title: "RxAlert",
                                message: "RxAlert Message",
                                actions: [AlertAction(title: "OK", type: 0, style: .default),
                                          AlertAction(title: "Cancel", type: 1, style: .destructive)])
                         .observeOn(MainScheduler.instance)
-                        .subscribe(onNext: { index in
+                        .subscribe(onSuccess: { index in
                             print("index: \(index)")
                         })
                         .disposed(by: self.disposeBag)
                     break
                 case 2:
-                    self.alert(title: "RxAlert",
+                    self.rx.alert(title: "RxAlert",
                                message: "RxAlert Message",
                                actions: [AlertAction(title: "OK")],
                                preferredStyle: .actionSheet)
                         .observeOn(MainScheduler.instance)
-                        .subscribe(onNext: { index in
+                        .subscribe(onSuccess: { index in
                             print("index: \(index)")
                         })
                         .disposed(by: self.disposeBag)
                     break
                 case 3:
-                    self.alert(title: "RxAlert",
+                    self.rx.alert(title: "RxAlert",
                                message: "RxAlert Message",
                                actions: [AlertAction(title: "OK", type: 0, style: .default),
                                          AlertAction(title: "First", type: 1, style: .default),
@@ -85,7 +85,7 @@ class ViewController: UIViewController {
                                          AlertAction(title: "Cancel", type: 2, style: .cancel)],
                                preferredStyle: .actionSheet)
                         .observeOn(MainScheduler.instance)
-                        .subscribe(onNext: { index in
+                        .subscribe(onSuccess: { index in
                             print("index: \(index)")
                         })
                         .disposed(by: self.disposeBag)
@@ -121,12 +121,12 @@ class ViewController: UIViewController {
          *****************************************/
         textField2.delegate = self
 
-        alert(title: "RxAlert",
+        self.rx.alert(title: "RxAlert",
               message: "We have made it easy to implement UIAlertController using RxSwift.",
               actions: [AlertAction(title: "OK", type: 0, style: .default),
                         AlertAction(textField: UITextField(), placeholder: "user name"),
                         AlertAction(textField: textField2, placeholder: "password")])
-            .subscribe(onNext: { (output) in
+            .subscribe(onSuccess: { (output) in
                 print("🤩The alert button has been tap.🤩")
                 output.textFields?.forEach {
                     if let text = $0.text {


### PR DESCRIPTION
Hi~ 👋 I brought two improvements! I will wait good feedback  😻.

1. Modify `RxAlert function` return type from `Observable` to `Single`.
Because `Observeable` means a sequence in which events are returned from 0 to N.
So I think it would be better to change the return type to `Single`, which returned only one event.

2. Most of `Rx` extended library wrote same format as `Reactive where Base: ~~`,
So I moved `RxAlert` code in `Reactive where Base: UIAlertViewController`

```swift
// before
viewController.alert(~~~)
alert.addActions(~~~)
// after
viewController.rx.alert(~~~)
alert.rx.addActions(~~~)
```